### PR TITLE
Option to use github login as display name

### DIFF
--- a/src/AwesomeGithubStats.Api/wwwroot/index.html
+++ b/src/AwesomeGithubStats.Api/wwwroot/index.html
@@ -118,6 +118,12 @@
                     <option>false</option>
                 </select>
 
+                <label for="preferLogin">Prefer login</label>
+                <select class="param" id="preferLogin" name="preferLogin" placeholder="false">
+                    <option>false</option>
+                    <option>true</option>
+                </select>
+
                 <details class="advanced">
                     <summary>⚙ Advanced Options</summary>
                     <div class="content parameters">

--- a/src/AwesomeGithubStats.Core/Models/Svgs/UserStatsCard.cs
+++ b/src/AwesomeGithubStats.Core/Models/Svgs/UserStatsCard.cs
@@ -62,9 +62,13 @@ namespace AwesomeGithubStats.Core.Models.Svgs
 
         public Stream Svg(string file, UserRank rank, CardStyles cardStyles, CardTranslations cardTranslations)
         {
+            var displayName = (string.IsNullOrEmpty(rank.UserStats.Name) || (_options.PreferLogin ?? false)) 
+                ? rank.UserStats.Login.Truncate(25)
+                : rank.UserStats.Name.Truncate(25);
+
             CalculateProgressBar(rank);
             var svgFinal = file
-                .Replace("{{Name}}", rank.UserStats.Name.Truncate(25))
+                .Replace("{{Name}}", displayName)
                 .Replace("{{Stars}}", rank.UserStats.TotalStars())
                 .Replace("{{Commits}}", rank.UserStats.TotalCommits())
                 .Replace("{{PRS}}", rank.UserStats.TotalPullRequests())

--- a/src/AwesomeGithubStats.Core/Models/UserStatsOptions.cs
+++ b/src/AwesomeGithubStats.Core/Models/UserStatsOptions.cs
@@ -12,6 +12,7 @@
         public string Border { get; set; }
         public string Ring { get; set; }
         public string CardType { get; set; } = "default";
+        public bool? PreferLogin { get; set; }
     }
 
 }


### PR DESCRIPTION
* New option `preferLogin`: when set makes svg use github `login` instead of `name` (default is false).
```url
?user=brunobritodev&cardType=level&theme=default&showIcons=true&preferLogin=false&properties=Background
```
![img](https://user-images.githubusercontent.com/15075638/213130432-00ce1e03-977e-4235-b418-e39cf1b4bd53.png)

* If gihub user `name` is null or empty - use `login` instead 
```csharp
var displayName = (string.IsNullOrEmpty(rank.UserStats.Name) || (_options.PreferLogin ?? false)) 
    ? rank.UserStats.Login.Truncate(25)
    : rank.UserStats.Name.Truncate(25);
```
![img](https://user-images.githubusercontent.com/15075638/213131365-a070c05c-cf96-4dc1-bd4b-e2b6e6b574eb.png)

ps. I don't know why rings are "rotated" that way in screenshots in my test build...

fixes #24